### PR TITLE
Add minimal Express WebSocket server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Figgie Game Server
+
+This is a basic server boilerplate for the Figgie game built with [Deno](https://deno.land/). It uses Express and the `ws` library via Deno's npm compatibility layer to provide HTTP and WebSocket capabilities.
+
+## Development
+
+```
+deno task dev
+```
+
+The server exposes a simple HTTP endpoint at `/` and sets up a WebSocket server for real-time communication.

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "dev": "deno run --watch main.ts"
+    "dev": "deno run --allow-net --watch main.ts"
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1"

--- a/main.ts
+++ b/main.ts
@@ -1,0 +1,32 @@
+import express from "npm:express";
+import { WebSocketServer } from "npm:ws";
+
+const app = express();
+const port = 3000;
+
+app.get('/', (_req, res) => {
+  res.send('Server is running');
+});
+
+const server = app.listen(port, () => {
+  console.log(`HTTP server listening on port ${port}`);
+});
+
+const wss = new WebSocketServer({ server });
+
+wss.on('connection', (ws) => {
+  console.log('WebSocket connection established');
+
+  ws.on('message', (message) => {
+    console.log('Received:', message.toString());
+    // Echo message back to client
+    ws.send(message.toString());
+  });
+
+  ws.on('close', () => {
+    console.log('WebSocket connection closed');
+  });
+});
+
+export { app, server, wss };
+


### PR DESCRIPTION
## Summary
- implement basic server in `main.ts` using Express and ws
- document how to start the server
- allow network permissions in the dev task

## Testing
- `deno task dev` *(fails: `bash: deno: command not found`)*